### PR TITLE
feat: millora la resiliència de xarxa del control de versions (timeout, retries i fallback a la versió en cau)

### DIFF
--- a/common/src/commonMain/kotlin/cat/bcn/commonmodule/data/datasource/remote/client/HttpClientFactory.kt
+++ b/common/src/commonMain/kotlin/cat/bcn/commonmodule/data/datasource/remote/client/HttpClientFactory.kt
@@ -61,10 +61,16 @@ fun buildClient(
         }
         block(this)
     }
+    // HttpRequestRetry re-runs the send pipeline on every retry attempt, so guard
+    // the metric so it is started only once per request (each client instance
+    // serves a single request). Avoids "metric already started" warnings while
+    // still measuring the full duration, retries included.
+    var metricStarted = false
     client.sendPipeline.intercept(HttpSendPipeline.Before) {
-        val url = context.url.buildString()
-        val httpMethod = context.method.value
-        metric?.start()
+        if (!metricStarted) {
+            metric?.start()
+            metricStarted = true
+        }
         proceed()
     }
     client.sendPipeline.intercept(HttpSendPipeline.Engine) {

--- a/common/src/commonMain/kotlin/cat/bcn/commonmodule/data/datasource/remote/client/HttpClientFactory.kt
+++ b/common/src/commonMain/kotlin/cat/bcn/commonmodule/data/datasource/remote/client/HttpClientFactory.kt
@@ -4,6 +4,8 @@ import cat.bcn.commonmodule.extensions.isDebug
 import cat.bcn.commonmodule.performance.PerformanceMetric
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
@@ -34,6 +36,17 @@ fun buildClient(
             }
 
             header("Authorization", "Basic b3NhbTpvc2Ft")
+        }
+        install(HttpTimeout) {
+            connectTimeoutMillis = 10_000
+            socketTimeoutMillis = 10_000
+            requestTimeoutMillis = 15_000
+        }
+        install(HttpRequestRetry) {
+            // Retry transient connectivity failures (DNS/connect/socket) and 5xx.
+            // GET endpoints (api/version, api/rating) are idempotent, so this is safe.
+            retryOnExceptionOrServerErrors(maxRetries = 2)
+            exponentialDelay(maxDelayMs = 3_000)
         }
         if (isDebug) {
             install(Logging) {

--- a/common/src/commonMain/kotlin/cat/bcn/commonmodule/data/repository/CommonRepository.kt
+++ b/common/src/commonMain/kotlin/cat/bcn/commonmodule/data/repository/CommonRepository.kt
@@ -31,34 +31,44 @@ internal class CommonRepository(
 
     suspend fun getVersion(language: Language): Either<CommonError, Version> {
         if (platformInformation.isOnline()) {
-            val versionResult = try {
-                CommonRepositoryUtils.getRemoteVersion(
-                    remote,
-                    internalPerformanceWrapper,
-                    platformInformation,
-                    preferences,
-                    language
+            return try {
+                Either.Right(
+                    CommonRepositoryUtils.getRemoteVersion(
+                        remote,
+                        internalPerformanceWrapper,
+                        platformInformation,
+                        preferences,
+                        language
+                    )
                 )
             } catch (e: Exception) {
-                return Either.Left(CommonError(e))
+                // The remote call failed, typically a transient connectivity
+                // failure on an unstable network. Instead of surfacing a
+                // recoverable error, fall back to the cached version, mirroring
+                // the offline branch below so the flow degrades gracefully.
+                Either.Right(getCachedVersionOrEmpty())
             }
-
-            return Either.Right(versionResult)
-
         } else {
-            val storedVersionCode = preferences.getVersionControlVersionCode()
-            val currentVersionCode = platformInformation.getVersionCode()
-
-            val cachedVersion = CommonRepositoryUtils.getCachedVersion(platformInformation, preferences)
-
             sendNoConnectionAnalytic(analytics, platformInformation)
+            return Either.Right(getCachedVersionOrEmpty())
+        }
+    }
 
-            if (storedVersionCode == 0L || storedVersionCode != currentVersionCode) {
-                val emptyVersion = cachedVersion.copy(comparisonMode = Version.ComparisonMode.NONE)
-                return Either.Right(emptyVersion)
-            }
+    /**
+     * Builds the version to use when the remote source is unavailable (device
+     * offline or a failed request). If there is no usable cache yet, or the app
+     * has been updated since the cache was stored, the comparison mode is forced
+     * to NONE so no dialog is shown based on stale data.
+     */
+    private fun getCachedVersionOrEmpty(): Version {
+        val storedVersionCode = preferences.getVersionControlVersionCode()
+        val currentVersionCode = platformInformation.getVersionCode()
+        val cachedVersion = CommonRepositoryUtils.getCachedVersion(platformInformation, preferences)
 
-            return Either.Right(cachedVersion)
+        return if (storedVersionCode == 0L || storedVersionCode != currentVersionCode) {
+            cachedVersion.copy(comparisonMode = Version.ComparisonMode.NONE)
+        } else {
+            cachedVersion
         }
     }
 


### PR DESCRIPTION
## Context del projecte

Fem servir aquesta llibreria (mòdul comú OSAM) a l'app de **Park Güell**. Hem observat un volum elevat d'errors de xarxa recuperables — principalment `BackendTimeoutException`, però també fallades de resolució DNS i de connexió — concentrats en escenaris de connectivitat dolenta (per exemple, usuaris dins del parc, on la cobertura és irregular).

En investigar-ho des de l'app vam veure que **tota la capa de xarxa està encapsulada dins de la llibreria i no és configurable des del costat de React Native**: ni els timeouts, ni una política de reintents, ni el comportament davant d'una petició fallida es poden ajustar des de l'app. Per tant no ho podem resoldre pel nostre costat, i obrim aquest PR amb una proposta de millora perquè la reviseu i, si us sembla bé, la incorporeu.

Aquest PR conté dos canvis independents i complementaris.

---

## Canvi 1 — Timeout i reintents al client Ktor compartit

`buildClient()` a `HttpClientFactory.kt` crea el `HttpClient` de Ktor compartit **sense cap timeout explícit ni cap política de reintents**. Conseqüències:

1. **Els timeouts depenen dels valors per defecte del motor**, que són diferents segons la plataforma (OkHttp a Android ≈ 10s vs. Darwin/NSURLSession a iOS ≈ 60s), de manera que el timeout efectiu és inconsistent entre plataformes. A més, la branca `catch (HttpRequestTimeoutException)` de `CommonRemoteDataSource` és, a la pràctica, codi mort, ja que aquesta excepció només es llança quan el plugin `HttpTimeout` està instal·lat.
2. **Una única fallada de connectivitat transitòria** (resolució DNS, connexió o socket) es propaga immediatament, sense cap segon intent. En xarxes mòbils inestables això genera una taxa elevada d'errors recuperables que un reintent curt absorbiria.

S'instal·len dos plugins estàndard de Ktor a `buildClient()`:

```kotlin
install(HttpTimeout) {
    connectTimeoutMillis = 10_000
    socketTimeoutMillis = 10_000
    requestTimeoutMillis = 15_000
}
install(HttpRequestRetry) {
    retryOnExceptionOrServerErrors(maxRetries = 2)
    exponentialDelay(maxDelayMs = 3_000)
}
```

Els endpoints afectats (`api/version`, `api/rating`) són `GET` idempotents, per tant els reintents automàtics són segurs. Tots dos plugins formen part de `ktor-client-core` (que ja és una dependència), així que **no s'afegeix cap dependència nova**.

Com que `HttpRequestRetry` torna a executar el pipeline d'enviament a cada reintent, també s'ha protegit la mètrica de rendiment perquè s'iniciï una sola vegada per petició (evita avisos de «metric already started»), tot mantenint la mesura de la durada completa, reintents inclosos.

---

## Canvi 2 — Fallback a la versió en cau quan la petició remota falla

**Per què és especialment rellevant en aquest cas d'ús:** a l'app de Park Güell el control de versions no només s'executa a l'arrencada, sinó **cada cop que l'app torna de background a foreground**, i en aquest escenari això passa molt sovint (els visitants obren i tornen a l'app contínuament mentre són al parc). Cada retorn a foreground dispara una petició de versió; combinat amb la cobertura irregular del parc, això genera moltes peticions sobre una xarxa inestable i, per tant, moltes fallades transitòries. Sense un fallback, cadascuna d'aquestes fallades es converteix en un error visible / non-fatal, tot i que l'usuari ja té dades vàlides en cau.

A `CommonRepository.getVersion()`, quan el dispositiu està en línia però la petició remota llança una excepció, es retornava `Either.Left(CommonError)`. Així, **qualsevol fallada transitòria de connectivitat es propagava com a error recuperable** a l'app (i es registrava com a non-fatal a Crashlytics), tot i que la branca offline ja sap degradar amb gràcia retornant la versió en cau.

Aquest canvi **reutilitza exactament el mateix fallback offline** per a les peticions en línia que fallen: en cas d'error, es retorna la versió en cau (amb `comparisonMode = NONE` quan no hi ha cau utilitzable o l'app s'ha actualitzat des que es va desar), en lloc de propagar un error. La lògica offline existent s'ha extret a un helper privat (`getCachedVersionOrEmpty()`) i ara la comparteixen les dues rutes; **el comportament offline no canvia**.

Així, una fallada de xarxa transitòria deixa de ser un error visible: l'app continua amb les dades en cau (mateix risc i comportament que la branca offline, que ja existia), i el control de versions es degrada amb gràcia en comptes de fallar.

---

## Notes

- Els valors de timeout/reintent són valors per defecte conservadors i fàcils d'ajustar.
- Amb el fallback del Canvi 2, una petició en línia que falla ja no genera un `CommonError`, de manera que tampoc es registra com a non-fatal. Si voleu conservar la mètrica de timeouts, es pot afegir un esdeveniment d'analytics al `catch`; ho deixo fora per mantenir el canvi mínim, però encantat d'afegir-ho.
- La reutilització de connexions (actualment el client es recrea a cada petició amb `.use { }`, sense pool ni keep-alive) és un canvi més gran que interacciona amb el disseny de la mètrica per petició, així que l'he deixat fora d'aquest PR com a possible millora futura.

## Verificació

`./gradlew :common:compileCommonMainKotlinMetadata` passa correctament (Ktor 3.0.0 / Kotlin 2.0.21).